### PR TITLE
Fix for G&W audio buffer overflow.

### DIFF
--- a/src/gw_sys/gw_system.c
+++ b/src/gw_sys/gw_system.c
@@ -191,7 +191,7 @@ static unsigned char mspeaker_data = 0;
 static int gw_audio_buffer_idx = 0;
 
 /* Audio buffer */
-unsigned char gw_audio_buffer[GW_AUDIO_BUFFER_LENGTH * 2];
+unsigned char gw_audio_buffer[GW_AUDIO_BUFFER_LENGTH];
 
 void gw_system_sound_init()
 {
@@ -246,9 +246,11 @@ static void gw_system_sound_melody(unsigned char data)
 		}
 	}
 
-	gw_audio_buffer[gw_audio_buffer_idx] = mspeaker_data;
-
-	gw_audio_buffer_idx++;
+	/* This will guard against overflows */
+	if (gw_audio_buffer_idx < sizeof(gw_audio_buffer)) {
+		gw_audio_buffer[gw_audio_buffer_idx] = mspeaker_data;
+		gw_audio_buffer_idx++;
+	}
 }
 
 void gw_writeR(unsigned char data) { gw_system_sound_melody(data); };

--- a/src/gw_sys/gw_system.h
+++ b/src/gw_sys/gw_system.h
@@ -72,7 +72,7 @@ void gw_system_set_time(gw_time_t time);
 gw_time_t gw_system_get_time();
 
 /* shared audio buffer between host and emulator */
-extern unsigned char gw_audio_buffer[GW_AUDIO_BUFFER_LENGTH * 2];
+extern unsigned char gw_audio_buffer[GW_AUDIO_BUFFER_LENGTH];
 
 /* Output of emulated system  */
 void gw_writeR(unsigned char data);


### PR DESCRIPTION
Fix for G&W audio buffer overflows when executing more than one frame of G&W cpu cycles.
Fix for G&W audio buffer bigger than needed.